### PR TITLE
Update URLs on Tech Talks README.md

### DIFF
--- a/Events/Tech Talks/README.md
+++ b/Events/Tech Talks/README.md
@@ -14,8 +14,7 @@
             <p>
             Tech Talks seek to inspire and educate students on topics that are emerging in the tech industry or are developer career-focused. We want them to compliment a computer science education in a more informal forum like a pre-hackathon talk, within student groups, or other visiting campus speaking or meetups. Each contains a presentation as well as speaker notes and coding demos. They are generally designed to be about 1 hour with Q&A - feel free edit them down to fit desired length. New contributions are welcome.
             </p>
-If you want to report any issues we need to fix. Please log an <a href="https://github.com/MSFTImagine/computerscience/issues">issue</a>. Include 
-            the content section (Tech Talk, Workshop, Course Content), module number and title, along with any error messages and screenshots. 
+            <p>If you want to report any issues we need to fix. Please log an <a href="https://github.com/Microsoft/computerscience/issues">issue</a>. Include the content section (Tech Talk, Workshop, Course Content), module number and title, along with any error messages and screenshots.</p>
  	 </div>
          </div>
          <div class="panel panel-default">
@@ -27,17 +26,17 @@ If you want to report any issues we need to fix. Please log an <a href="https://
 			<table class="table table-bordered table-striped table-hover">
 					<tr>
 					   <td><b>A Career in Technical Evangelism: What we really do.</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20A%20career%20in%20developer%20evangelism.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20A%20career%20in%20developer%20evangelism.pptx">Presentation</a></td>
 					   <td>Do you love sharing technology with other people as much as you love building things yourself? Want to help others be successful while building your commmunication and coding skills in parallel? Learn about this exciting career path from people who live it everyday. </td>
 					</tr>
 					<tr>
 					   <td><b>Setting-up the Perfect Online Resume for Student Devs</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Setting%20up%20the%20Perfect%20Online%20Resume%20for%20Student%20Devs.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Setting%20up%20the%20Perfect%20Online%20Resume%20for%20Student%20Devs.pptx">Presentation</a></td>
 					   <td>Ready to share your talent with startups, agencies, and big tech companies? There's nothing better than <i>showing</i> them. Take the first step by creating your own online resume and portfolio of projects, hosted in the Azure Cloud. </td>
 					</tr>
 					<tr>
 					   <td><b>Your First Startup:How to move investors to YES!</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20How%20to%20move%20investors%20to%20Yes.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20How%20to%20move%20investors%20to%20Yes.pptx">Presentation</a></td>
 					   <td>Thinking about building the next great thing? Deciding to bootstrap or raise some capital? This talk guides you through the realities, the process, and how to pitch investors towards your big career breakthrough. </td>
 					</tr>
 			</table>
@@ -45,32 +44,32 @@ If you want to report any issues we need to fix. Please log an <a href="https://
 			<table class="table table-bordered table-striped table-hover">
 				<tr>
 					   <td><b>Introduction to Cloud Computing</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Introduction%20to%20Cloud%20Computing.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Introduction%20to%20Cloud%20Computing.pptx">Presentation</a></td>
 					   <td>Overview of cloud technology and features.</td>
 					</tr>
 					<tr>
 					   <td><b>Using Cortana Intelligence Suite in your Hacks or Student Projects</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Using%20Cortana%20Intelligence%20Suite%20in%20your%20Hacks%20or%20Student%20Projects.pptx">Presentation</a> | <a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Demos%20-%20Using%20Cortana%20Intelligence%20Suite%20in%20your%20Hacks%20or%20Student%20Projects.zip">Demos</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Using%20Cortana%20Intelligence%20Suite%20in%20your%20Hacks%20or%20Student%20Projects.pptx">Presentation</a> | <a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Demos%20-%20Using%20Cortana%20Intelligence%20Suite%20in%20your%20Hacks%20or%20Student%20Projects.zip">Demos</a></td>
 					   <td>Want to make your apps more intelligent with minimal additional work? Today's cloud has the power to help you create something more <i>human</i>. Learn about the characteristics of an intelligent app and see some great demos of what's possible with contextual vision, speech, knowledge, language, and search.</td>
 					</tr>
 					<tr>
 					   <td><b>Build an Intelligent Dorm Room Security System with Cognitive Services</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Build%20an%20Intelligent%20Dorm%20Room%20Security%20System.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Build%20an%20Intelligent%20Dorm%20Room%20Security%20System.pptx">Presentation</a></td>
 					   <td>Welcome your friends, know your foes with a fun and intelligent "internet of things" project using a Raspberry Pi, Windows 10, Microsoft Azure, and a few cheap components. The skills you build may very well be a bigger step towards your career in making.</td>
 					</tr>
 					<tr>
 					   <td><b>Microsoft A.I. Conversational UI & Cognitive Services</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20MicrosoftAI%20ConversationalUI%20%26%20Cognitive.pdf">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20MicrosoftAI%20ConversationalUI%20%26%20Cognitive.pdf">Presentation</a></td>
 					   <td>Understanding Microsoft AI Strategy and how conversation as a service can build intelligent apps</td>
 					</tr>
 					<tr>
 					   <td><b>Microsoft Machine Learning demystified</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Machine%20Learning%20Demystified.pptx">Presentation</a> | <a href="https://github.com/MSFTImagine/computerscience/blob/master/Workshop/4.%20Machine%20Learning/Azure%20Machine%20Learning%20HOL%20(UWP).md">Demos</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Machine%20Learning%20Demystified.pptx">Presentation</a> | <a href="https://github.com/Microsoft/computerscience/blob/master/Workshop/4.%20Machine%20Learning/Azure%20Machine%20Learning%20HOL%20(UWP).md">Demos</a></td>
 					   <td>Understand Microsoft Machine Learning </td>
 					</tr>
 					<tr>
 					   <td><b>Microsoft Cognitive Services adding smarts to your applications</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Machine%20Learning%20Cognitive%20%26%20Bots.pdf">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Machine%20Learning%20Cognitive%20%26%20Bots.pdf">Presentation</a></td>
 					   <td>Understand Microsoft Machine Learning, Cognitive Services and the Bot Framework and the opportunity of using these services to add smarts to your applications the perfect services for your hackathon and challenges</td>
 					</tr>
 			</table>
@@ -78,17 +77,17 @@ If you want to report any issues we need to fix. Please log an <a href="https://
 			<table class="table table-bordered table-striped table-hover">
 					<tr>
 					   <td><b>Azure Compute Cloud - Introduction to Service Fabric and Azure Compute</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Azure%20compute%20cloud.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Azure%20compute%20cloud.pptx">Presentation</a></td>
 					   <td>Understand all about Compute Offerings from VMs to Container Services</td>
 					</tr>
 						<tr>
 					   <td><b>Microsoft and Containers - So what are Containers learn all about the various option</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Microsoft%20and%20Containers.pptx">Presentation</a> | <a href="https://github.com/MSFTImagine/computerscience/tree/master/Tech%20Talks/ContainerDemo">Demos</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Microsoft%20and%20Containers.pptx">Presentation</a> | <a href="https://github.com/Microsoft/computerscience/tree/master/Events/Tech%20Talks/ContainerDemo">Demos</a></td>
 					   <td>Understand Containers we discuss the difference between Windows Server Containers, Hyper V Containers, Docker on Windows, Azure Container and share examples and demos for each with details on the docker release pipeline</td>
 					</tr>
 					<tr>
 					   <td><b>Azure Storage Overview - Using Microsoft Azure for Storage Services </b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20AzureStorageOverview.pptx">Presentation</a> | <a href="https://github.com/MSFTImagine/computerscience/tree/master/Tech%20Talks/StorageDemo">Demos</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20AzureStorageOverview.pptx">Presentation</a> | <a href="https://github.com/Microsoft/computerscience/tree/master/Events/Tech%20Talks/StorageDemo">Demos</a></td>
 					   <td>Understand Microsoft Azure Storage Services Demos are located in storage Demo Folder</td>
 					</tr>
 			</table>
@@ -96,37 +95,37 @@ If you want to report any issues we need to fix. Please log an <a href="https://
                <table class="table table-bordered table-striped table-hover">
 					<tr>
 					   <td><b>Using Bots in your Hackathon project - Introduction to Bots</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Using%20Bots%20in%20Your%20Hackathon%20Project.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Using%20Bots%20in%20Your%20Hackathon%20Project.pptx">Presentation</a></td>
 					   <td>Understand the components of a Bot including how LUIS and intelligence fit in</td>
 					</tr>
 					<tr>
 					   <td><b>Bots are the New Apps - Introduction to Microsoft Bot Framework</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Bots%20Are%20the%20New%20Apps.pptx">Presentation</a> | <a href="https://github.com/MSFTImagine/computerscience/tree/master/Tech%20Talks/busbot">Demos</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Bots%20Are%20the%20New%20Apps.pptx">Presentation</a> | <a href="https://github.com/Microsoft/computerscience/tree/master/Events/Tech%20Talks/busbot">Demos</a></td>
 					   <td>Understand all about Microsoft Bot Framework and build your first bot</td>
 					</tr>
 					<tr>
 					   <td><b>Cybersecurity - an Ever Moving Target</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Cybersecurity%20an%20Ever%20Moving%20Target.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Cybersecurity%20an%20Ever%20Moving%20Target.pptx">Presentation</a></td>
 					   <td>Black hats, White hats, the Dark Web, Bitcoin. What do they all have in-common? Cybersecurity is one of the fastest growing careers for developers. This talk is all about what hacking really means: motivations, scale, attack vectors, and countermeasures.</td>
 					</tr>
 					<tr>
 					   <td><b>Virtual Reality - The Past, Present, and the Future that Starts Right Now</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20The%20tech%20path%20towards%20Augmented%20and%20Virtual%20Reality.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20The%20tech%20path%20towards%20Augmented%20and%20Virtual%20Reality.pptx">Presentation</a></td>
 					   <td>You can't have a conversation about emerging tech without virtual and augmented reality quickly coming up. But did you know that developers have been experimenting with it for decades? Learn about past experiences that paved the way and why now is the time for mixed reality experiences to explode in popularity and potential.  </td>
 					</tr>
 						<tr>
 					   <td><b>Microsoft Power BI - So what is PowerBI learn all about the various option for using PowerBI to visualise Data</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20PowerBI_StudentPresentation.pptx">Presentation</a> | <a href="https://blogs.msdn.microsoft.com/uk_faculty_connection/2016/08/31/visualisation-of-data-with-power-bi/">Tutorial</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20PowerBI_StudentPresentation.pptx">Presentation</a> | <a href="https://blogs.msdn.microsoft.com/uk_faculty_connection/2016/08/31/visualisation-of-data-with-power-bi/">Tutorial</a></td>
 					   <td>Understand PowerBI we discuss the difference the history of data visualisation and then the various way PowerBI can visualise data</td>
 					</tr>
 						<tr>
 					   <td><b>Microsoft Power BI and REST Services - Samples of how to use REST APIS to build amazing data visualisations</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20PowerBI_RESTSamples_student.pptx">Presentation</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20PowerBI_RESTSamples_student.pptx">Presentation</a></td>
 					   <td>Understand PowerBI APIs samples and demos</td>
 					   </tr>
 					<tr>
 					   <td><b>Microsoft Xbox One - Building Windows 10 UWP Apps and Games for Xbox One</b></td>
-					   <td><a href="https://github.com/MSFTImagine/computerscience/blob/master/Tech%20Talks/Tech%20Talk%20-%20Building%20UWP%20Apps%20&%20Games%20for%20XboxOne.pptx">Presentation</a> | <a href="https://github.com/MSFTImagine/computerscience/tree/master/Tech%20Talks/XboxOneUWPDemo">Demos</a></td>
+					   <td><a href="https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks/Tech%20Talk%20-%20Building%20UWP%20Apps%20&%20Games%20for%20XboxOne.pptx">Presentation</a> | <a href="https://github.com/Microsoft/computerscience/tree/master/Events/Tech%20Talks/XboxOneUWPDemo">Demos</a></td>
 					   <td>Understand Microsoft Xbox One UWP App and Game development building UWP Games and Apps with C#, Unity3d and MonoGame</td>
 					</tr>
 				 </table>


### PR DESCRIPTION
Updated anchors from https://github.com/MSFTImagine/computerscience/tree/master/Tech%20Talks to https://github.com/Microsoft/computerscience/blob/master/Events/Tech%20Talks