### PR TITLE
Remove Invalid URL for Bots Workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We also have other great educator content to help you use Azure in the classroom
 | Resource | |
 | - | - |
 | [Technical Community Content](https://github.com/Microsoft/TechnicalCommunityContent) | Workshops from the community team. |
-| [Bots workshop](http://aka.ms/NUSworkshop) | Bots and LUIS workshop from Singapore team. |
+| Bots workshop | Bots and LUIS workshop from Singapore team. |
 | [Cognitive Tookit](https://github.com/Microsoft/CNTK/wiki/Setup-Windows-Binary-Script) | Resources to set up Cognitive Toolkit using notebooks from product team. After installing tutorials will be in c:\repos\bindings\python\tutorials. |
 | [Research case studies](https://www.microsoft.com/en-us/research/academic-program/microsoft-azure-for-research/) | Case studies of faculty using Azure for Research collected by Microsoft Research. Submit your own Azure research stories here too! |
 | [Microsoft Research Data Sets](http://aka.ms/datascience) | Data sets shared by Microsoft Research for academic use. |


### PR DESCRIPTION
Remove the invalid URL ([Bots workshop](http://aka.ms/NUSworkshop)) because the URL Redirect to "https://www.microsoft.com/en-sg/"