### PR TITLE
Update LICENSE.md to use actual MIT license text

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,6 @@
 The MIT License (MIT)
 
-MSFTImagine/computerscience
-
-Copyright (c) Microsoft Corporation
-All rights reserved. 
+Copyright (c) 2016 Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
https://opensource.org/licenses/MIT shows that the only changes allowed to the text are the year and copyright holder. "All rights reserved" is obsolete and unnecessary, according to https://opensource.stackexchange.com/questions/2121/mit-license-and-all-rights-reserved#4403 and MSFTImagine/computerscience points to this repo (Microsoft/computerscience), so it's unnecessary.